### PR TITLE
Mention arbitrary CSS passing to values in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,22 @@ const Box = styled.div`
 `;
 ```
 
+The values can also be any CSS blob (just make sure to stay consistent for all modes).
+
+```js
+import styled, {css} from 'styled-components';
+import theme from 'styled-theming';
+
+const stylesByMode = theme('mode', {
+  funky: css`color: #fff; font-weight: bold;`,
+  fun: css`color: #000; font-style: italic;`,
+});
+
+const Box = styled.div`
+  ${stylesByMode}
+`;
+```
+
 ### `theme.variants(name, prop, themes)`
 
 It's often useful to create variants of the same component that are selected

--- a/README.md
+++ b/README.md
@@ -135,19 +135,30 @@ const Box = styled.div`
 `;
 ```
 
-The values can also be any CSS blob (just make sure to stay consistent for all modes).
+The values will be passed through like any other interpolation
+in styled-components. You can use the `css` helper to add entire
+blocks of styles, including their own interpolations.
 
 ```js
 import styled, {css} from 'styled-components';
 import theme from 'styled-theming';
 
-const stylesByMode = theme('mode', {
-  funky: css`color: #fff; font-weight: bold;`,
-  fun: css`color: #000; font-style: italic;`,
+const white = "#fff";
+const black = "#000";
+
+const boxStyles = theme('mode', {
+  light: css`
+    background: ${white};
+    color: ${black};
+  `,
+  dark: css`
+    background: ${black};
+    color: ${white};
+  `,
 });
 
 const Box = styled.div`
-  ${stylesByMode}
+  ${boxStyles}
 `;
 ```
 


### PR DESCRIPTION
Great library! Thanks!

Assuming it isn't an anti-pattern (seems potentially ergonomic in some cases), it may be worth making a note in the docs that any arbitrary CSS string can be passed (you aren't limited to just passing CSS values). Instead of having a declaration for every CSS value being filtered by mode, you can have group a few rules.