### PR TITLE
Add a defaultValue fallback for theme

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function getThemeValue(name, props, values) {
   if (typeof value === 'function') {
     themeValue = value(values);
   } else {
-    themeValue = values[value];
+    themeValue = values[value] || values.defaultValue;
   }
 
   if (typeof themeValue === 'function') {


### PR DESCRIPTION
There are cases where I want to have a default value applied. I understand that I could do this like so:
```
const getFooterOverrides = theme('mode', {
  foo: p => p.theme.colors.red
})

const Footer = styled.footer`
  color: blue;
  color: ${getFooterOverrides}
`
```

I run into problems with this approach when I'm using `attrs`, and have to do things like: 

```
const StyledPopUp = styled(PopUpIcon).attrs({
  color: p => getFooterOverrides(p) || 'blue'
})`
  margin-left: 4px;
`
```

It'd be really nice to just have: 
```
const getFooterOverrides = theme('mode', {
  defaultValue: 'blue'
  foo: p => p.theme.colors.red
})
```
And then simply say ...
```
const StyledPopUp = styled(PopUpIcon).attrs({
  color: getFooterOverrides
})`
  margin-left: 4px;
`