### PR TITLE
Add support for boolean values for theme.variants

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function theme(name, values) {
 
 theme.variants = function(name, prop, values) {
   return function(props) {
-    var variant = props[prop] && values[props[prop]];
+    var variant = typeof props[prop] !== 'undefined' && values[props[prop]];
     return variant && getThemeValue(name, props, variant);
   };
 };


### PR DESCRIPTION
Because the docs dont explicitly say otherwise, I assumed that boolean values would work as keys in the `values` object passed to `theme.variants()`. After some debugging and looking through the source I realized this wasnt possible because of a conditional that checked if the value's key was truthy.

These changes explicitly check if the value's key is undefined, which allows props passed to the styled Component to be boolean values.

Example usage: 

```
theme.variants('someMode', 'hasSomeProp', {
  [true]: {
    light: 'some value',
    dark: 'some darker value',
  },
  [false]: {
    light: 'some other value',
    dark: 'some other darker value',
  }
})
```